### PR TITLE
Add error handling

### DIFF
--- a/lib/myinfo/v3/api.rb
+++ b/lib/myinfo/v3/api.rb
@@ -17,6 +17,12 @@ module MyInfo
         raise NotImplementedError, 'abstract'
       end
 
+      def call
+        yield
+      rescue StandardError => e
+        Response.new(success: false, data: e)
+      end
+
       def slug
         ''
       end

--- a/lib/myinfo/v3/person.rb
+++ b/lib/myinfo/v3/person.rb
@@ -14,11 +14,13 @@ module MyInfo
       end
 
       def call
-        headers = header(params: params, access_token: access_token)
-        endpoint_url = "/#{slug}?#{params.to_query}"
+        super do
+          headers = header(params: params, access_token: access_token)
+          endpoint_url = "/#{slug}?#{params.to_query}"
 
-        response = http.request_get(endpoint_url, headers)
-        parse_response(response)
+          response = http.request_get(endpoint_url, headers)
+          parse_response(response)
+        end
       end
 
       def slug

--- a/lib/myinfo/v3/person_basic.rb
+++ b/lib/myinfo/v3/person_basic.rb
@@ -15,11 +15,13 @@ module MyInfo
       end
 
       def call
-        headers = header(params: params)
-        endpoint_url = "/#{slug}?#{params.to_query}"
+        super do
+          headers = header(params: params)
+          endpoint_url = "/#{slug}?#{params.to_query}"
 
-        response = http.request_get(endpoint_url, headers)
-        parse_response(response)
+          response = http.request_get(endpoint_url, headers)
+          parse_response(response)
+        end
       end
 
       def slug

--- a/lib/myinfo/v3/response.rb
+++ b/lib/myinfo/v3/response.rb
@@ -15,8 +15,12 @@ module MyInfo
         @success
       end
 
+      def exception?
+        data.is_a?(StandardError)
+      end
+
       def to_s
-        data
+        exception? ? data.message : data
       end
     end
   end

--- a/lib/myinfo/v3/token.rb
+++ b/lib/myinfo/v3/token.rb
@@ -12,10 +12,12 @@ module MyInfo
       end
 
       def call
-        headers = header(params: params).merge({ 'Content-Type' => 'application/x-www-form-urlencoded' })
-        response = http.request_post("/#{slug}", params.to_param, headers)
+        super do
+          headers = header(params: params).merge({ 'Content-Type' => 'application/x-www-form-urlencoded' })
+          response = http.request_post("/#{slug}", params.to_param, headers)
 
-        parse_response(response)
+          parse_response(response)
+        end
       end
 
       def http_method

--- a/spec/lib/myinfo/v3/person_spec.rb
+++ b/spec/lib/myinfo/v3/person_spec.rb
@@ -32,6 +32,8 @@ describe MyInfo::V3::Person do
                    'attributes=testing,test2&client_id=test-client&sp_esvcId=service_id').to_return(response)
     end
 
+    subject { described_class.call(access_token: 'token', attributes: %w[testing test2]) }
+
     context 'successful response' do
       let(:response) do
         {
@@ -40,11 +42,23 @@ describe MyInfo::V3::Person do
         }
       end
 
-      subject { described_class.call(access_token: 'token', attributes: %w[testing test2]) }
-
       it 'should return the correct response' do
         expect(subject).to be_success
         expect(subject.data).to eql('')
+      end
+    end
+
+    context 'with exception' do
+      let(:response) { {} }
+
+      before do
+        allow_any_instance_of(Net::HTTP).to receive(:request_get).and_raise(Net::ReadTimeout, 'timeout')
+      end
+
+      it 'should return a false response' do
+        expect(subject).not_to be_success
+        expect(subject).to be_exception
+        expect(subject.to_s).to eql('Net::ReadTimeout with "timeout"')
       end
     end
   end

--- a/spec/lib/myinfo/v3/response_spec.rb
+++ b/spec/lib/myinfo/v3/response_spec.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
 describe MyInfo::V3::Response do
-  subject { described_class.new(success: true, data: 'some data') }
+  context 'successful' do
+    subject { described_class.new(success: true, data: 'some data') }
 
-  it { expect(subject).to be_success }
-  it { expect(subject.to_s).to eql('some data') }
+    it { expect(subject).to be_success }
+    it { expect(subject).not_to be_exception }
+    it { expect(subject.to_s).to eql('some data') }
+  end
+
+  context 'with exception' do
+    subject { described_class.new(success: false, data: Net::ReadTimeout.new('hello')) }
+
+    it { expect(subject).not_to be_success }
+    it { expect(subject).to be_exception }
+    it { expect(subject.to_s).to eql('Net::ReadTimeout with "hello"') }
+  end
 end

--- a/spec/lib/token_spec.rb
+++ b/spec/lib/token_spec.rb
@@ -80,5 +80,19 @@ describe MyInfo::V3::Token do
         expect(subject.data).to eql('500 - some unexpected message')
       end
     end
+
+    context 'with exception' do
+      let(:response) { {} }
+
+      before do
+        allow_any_instance_of(Net::HTTP).to receive(:request_post).and_raise(Net::ReadTimeout, 'timeout')
+      end
+
+      it 'should return a false response' do
+        expect(subject).not_to be_success
+        expect(subject).to be_exception
+        expect(subject.to_s).to eql('Net::ReadTimeout with "timeout"')
+      end
+    end
   end
 end


### PR DESCRIPTION
Add error handling for API calls with Person, PersonBasic and Token. This allows the library to exit gracefully if there is a readtimeout or other exceptions that should not exist, while still storing the error which can then be logged afterwards.