### PR TITLE
V4 Security Helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     myinfo (0.5.4)
+      jose (~> 0.1.0)
       jwe (~> 0.4)
       jwt (~> 2.2)
 
@@ -80,12 +81,16 @@ GEM
     erubi (1.11.0)
     globalid (1.0.1)
       activesupport (>= 5.0)
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    jose (0.1.0)
+      hamster
     json (2.6.2)
     jwe (0.4.0)
-    jwt (2.5.0)
+    jwt (2.7.1)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,11 @@ PATH
   remote: .
   specs:
     myinfo (0.5.4)
-      jose (~> 0.1.0)
+      jose (~> 1.1.3)
+      json-jwt
       jwe (~> 0.4)
       jwt (~> 2.2)
+      pry-rails
 
 GEM
   remote: http://rubygems.org/
@@ -70,8 +72,11 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
+    bindata (2.4.15)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
@@ -79,6 +84,12 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubi (1.11.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.0.2)
     globalid (1.0.1)
       activesupport (>= 5.0)
     hamster (3.0.0)
@@ -86,9 +97,15 @@ GEM
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jose (0.1.0)
+    jose (1.1.3)
       hamster
     json (2.6.2)
+    json-jwt (1.16.3)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     jwe (0.4.0)
     jwt (2.7.1)
     loofah (2.19.1)
@@ -108,6 +125,11 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.0)
     puma (6.0.0)
       nio4r (~> 2.0)
@@ -179,6 +201,7 @@ GEM
     rubocop-ast (1.23.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/myinfo.rb
+++ b/lib/myinfo.rb
@@ -16,6 +16,8 @@ require_relative 'myinfo/v3/person'
 require_relative 'myinfo/v3/person_basic'
 require_relative 'myinfo/v3/authorise_url'
 
+require_relative 'myinfo/v4/security'
+
 # Base MyInfo class
 module MyInfo
   class << self

--- a/lib/myinfo/v4/security.rb
+++ b/lib/myinfo/v4/security.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'base64'
+require 'digest'
+require 'openssl'
+require 'jwt'
+
+module MyInfo
+    module V4
+        class Security
+            def self.create_code_verifier 
+                code = SecureRandom.bytes(32)
+                Base64.urlsafe_encode64(code, padding: false)
+            end
+
+            def self.create_code_challenge(verifier)
+                bytes = verifier.encode('US-ASCII')
+                digest = Digest::SHA256.digest(bytes)
+                Base64.urlsafe_encode64(digest, padding: false)
+            end
+
+            def self.generate_ephemeral_keys
+                key_pair = OpenSSL::PKey::EC.new("prime256v1")
+                key_pair.generate_key
+              
+                private_key = key_pair.to_pem
+                public_key = OpenSSL::PKey::EC.new(key_pair.public_key.group)
+                public_key.public_key = key_pair.public_key
+                public_key = public_key.to_pem
+              
+                { private_key: private_key, public_key: public_key }
+            end
+
+            def get_jwks(jwks_url)
+                raise NotImplementedError
+            end
+
+            def verify_jws(compact_jws, jwks_url)
+                raise NotImplementedError
+            end
+
+            def decrypt_jwe(compact_jwe, decryption_private_key)
+                raise NotImplementedError
+            end
+
+            def self.generate_jwk_thumbprint(jwk)
+                jwk_key = OpenSSL::PKey::RSA.new(jwk)
+                jwk_thumbprint = Digest::SHA256.digest(jwk_key.public_key.to_der)
+                jwk_thumbprint_encoded = Base64.urlsafe_encode64(jk_thumbprint)
+
+                jwk_thumbprint_encoded
+            end
+
+            def self.generate_client_assertion(url, client_id, private_signing_key, jkt_thumbprint, kid)
+                now = Time.now.to_i
+                payload = {
+                    sub: client_id,
+                    jti: SecureRandom.alphanumeric(40),
+                    aud: url,
+                    iss: client_id,
+                    iat: now,
+                    exp: now + 300,
+                    cnf: {
+                        jkt: jkt_thumbprint
+                    }
+                }
+
+                private_key = OpenSSL::PKey.read(private_signing_key)
+                headers = {
+                    'typ' => 'JWT',
+                    'kid' => kid
+                }
+
+                jwt_token = JWT.encode(payload, private_key, 'RS256', headers)
+
+                jwt_token
+            end
+
+            def generateDPoP(url, ath, method, session_ephemeral_key_pair)
+                raise NotImplementedError
+            end
+        end
+    end
+end

--- a/lib/myinfo/v4/security.rb
+++ b/lib/myinfo/v4/security.rb
@@ -12,132 +12,128 @@ require 'jose'
 require 'jose/jwe'
 
 module MyInfo
-    module V4
-        class Security
-            def config
-                MyInfo.configuration
-            end
+  module V4
+    class Security
+      def config
+        MyInfo.configuration
+      end
 
-            def get_private_key
-                raise MissingConfigurationError, :private_key if config.private_key.blank?
-        
-                OpenSSL::PKey::RSA.new(config.private_key)
-            end
+      def get_private_key
+        raise MissingConfigurationError, :private_key if config.private_key.blank?
 
-            # done & tested
-            def self.create_code_verifier 
-                code = SecureRandom.bytes(32)
-                Base64.urlsafe_encode64(code, padding: false)
-            end
+        OpenSSL::PKey::RSA.new(config.private_key)
+      end
 
-            # done & tested
-            def self.create_code_challenge(verifier)
-                bytes = verifier.encode('US-ASCII')
-                digest = Digest::SHA256.digest(bytes)
-                Base64.urlsafe_encode64(digest, padding: false)
-            end
+      # done & tested
+      def self.create_code_verifier
+        code = SecureRandom.bytes(32)
+        Base64.urlsafe_encode64(code, padding: false)
+      end
 
-            # not yet tested
-            def self.generate_ephemeral_keys
-                key_pair = OpenSSL::PKey::EC.new("prime256v1")
-                key_pair.generate_key
-              
-                private_key = key_pair.to_pem
-                public_key = OpenSSL::PKey::EC.new(key_pair.public_key.group)
-                public_key.public_key = key_pair.public_key
-                public_key = public_key.to_pem
-              
-                { private_key: private_key, public_key: public_key }
-            end
+      # done & tested
+      def self.create_code_challenge(verifier)
+        bytes = verifier.encode('US-ASCII')
+        digest = Digest::SHA256.digest(bytes)
+        Base64.urlsafe_encode64(digest, padding: false)
+      end
 
-            def self.generate_ephemeral_keys_jose
-                private_key = JOSE::JWK.generate_key([:ec, "prime256v1"])
-                public_key = JOSE::JWK.to_public(private_key)
-                
-                { private_key: private_key.to_pem, public_key: public_key.to_pem }
-            end
+      # not yet tested
+      def self.generate_ephemeral_keys
+        key_pair = OpenSSL::PKey::EC.new("prime256v1")
+        key_pair.generate_key
 
-            # not yet tested
-            def get_jwks(jwks_url)
-                uri = URI(jwks_url)
-                response = Net::HTTP.get_response(uri)
+        private_key = key_pair.to_pem
+        public_key = OpenSSL::PKey::EC.new(key_pair.public_key.group)
+        public_key.public_key = key_pair.public_key
+        public_key = public_key.to_pem
 
-                if response.is_a?(Net::HTTPSuccess)
-                    response_body = response.body
-                    response_data = JSON.parse(response_body)
+        { private_key: private_key, public_key: public_key }
+      end
 
-                    response_data['keys']
-                else 
-                    # Todo: Handle Error
-                end
-            end
+      def self.generate_ephemeral_keys_jose
+        private_key = JOSE::JWK.generate_key([:ec, "prime256v1"])
+        public_key = JOSE::JWK.to_public(private_key)
 
-            def self.decode_jws(compact_jws, public_key)
-                JWT.decode(jws, public_key, true, algorithm: 'ES256').first
-            end
-            
-            def decrypt_jwe_with_key(compact_jwe, decryption_private_key)
-                jwe_parts = compact_jwe.split('.') # header.encryptedKey.iv.ciphertext.tag
-                raise 'Invalid data or signature' if jwe_parts.length != 5
-                
-                # Session encryption private key should correspond to the session encryption public key passed in to client assertion
-                key = JOSE::JWK.from_pem(decryption_private_key)
-                
-                data = {
-                    'type' => 'compact',
-                    'protected' => jwe_parts[0],
-                    'encrypted_key' => jwe_parts[1],
-                    'iv' => jwe_parts[2],
-                    'ciphertext' => jwe_parts[3],
-                    'tag' => jwe_parts[4],
-                    'header' => JSON.parse(JOSE::Util.base64url_decode(jwe_parts[0]).to_s)
-                }
-                
-                jwe = JOSE::JWE.from_serialized_compact(data.to_json)
-                result = jwe.decrypt(key)
-                
-                result.payload.to_s
-            rescue => error
-            'Error decrypting JWE'
-            end
-            
+        { private_key: private_key.to_pem, public_key: public_key.to_pem }
+      end
 
-            # done & tested
-            def self.generate_jwk_thumbprint(jwk)
-                jwk_key = OpenSSL::PKey.read(jwk) # convert pem to OpenSSL::PKey::PKey object
-                jwk = JSON::JWK.new(jwk_key)
-                jwk.thumbprint('sha256')
-            end
+      # not yet tested
+      def get_jwks(jwks_url)
+        uri = URI(jwks_url)
+        response = Net::HTTP.get_response(uri)
 
-            # done & tested
-            def self.generate_client_assertion(url, client_id, private_signing_key, jwk_thumbprint, kid)
-                now = Time.now.to_i
-                payload = {
-                    sub: client_id,
-                    jti: SecureRandom.alphanumeric(40),
-                    aud: url,
-                    iss: client_id,
-                    iat: now,
-                    exp: now + 300,
-                    cnf: {
-                        jkt: jwk_thumbprint
-                    }
-                }
+        if response.is_a?(Net::HTTPSuccess)
+          response_body = response.body
+          response_data = JSON.parse(response_body)
 
-                private_key = OpenSSL::PKey.read(private_signing_key)
-                headers = {
-                    'typ' => 'JWT',
-                    'kid' => kid
-                }
-
-                jwt_token = JWT.encode(payload, private_key, 'ES256', headers)
-
-                jwt_token
-            end
-
-            def generateDPoP(url, ath, method, session_ephemeral_key_pair)
-                raise NotImplementedError
-            end
+          response_data['keys']
+        else
+          # TODO: Handle Error
         end
+      end
+
+      def self.decode_jws(compact_jws, public_key)
+        JWT.decode(jws, public_key, true, algorithm: 'ES256').first
+      end
+
+      def decrypt_jwe_with_key(compact_jwe, decryption_private_key)
+        jwe_parts = compact_jwe.split('.') # header.encryptedKey.iv.ciphertext.tag
+        raise 'Invalid data or signature' if jwe_parts.length != 5
+
+        # Session encryption private key should correspond to the session encryption public key passed in to client assertion
+        key = JOSE::JWK.from_pem(decryption_private_key)
+
+        data = {
+          'type' => 'compact',
+          'protected' => jwe_parts[0],
+          'encrypted_key' => jwe_parts[1],
+          'iv' => jwe_parts[2],
+          'ciphertext' => jwe_parts[3],
+          'tag' => jwe_parts[4],
+          'header' => JSON.parse(JOSE::Util.base64url_decode(jwe_parts[0]).to_s)
+        }
+
+        jwe = JOSE::JWE.from_serialized_compact(data.to_json)
+        result = jwe.decrypt(key)
+        result.payload.to_s
+      rescue => error
+        'Error decrypting JWE'
+      end
+
+
+      # done & tested
+      def self.generate_jwk_thumbprint(jwk)
+        jwk_key = OpenSSL::PKey.read(jwk) # convert pem to OpenSSL::PKey::PKey object
+        jwk = JSON::JWK.new(jwk_key)
+        jwk.thumbprint('sha256')
+      end
+
+      # done & tested
+      def self.generate_client_assertion(url, client_id, private_signing_key, jwk_thumbprint, kid)
+        now = Time.now.to_i
+        payload = {
+          sub: client_id,
+          jti: SecureRandom.alphanumeric(40),
+          aud: url,
+          iss: client_id,
+          iat: now,
+          exp: now + 300,
+          cnf: {
+            jkt: jwk_thumbprint
+          }
+        }
+
+        private_key = OpenSSL::PKey.read(private_signing_key)
+        headers = {
+          'typ' => 'JWT',
+          'kid' => kid
+        }
+        JWT.encode(payload, private_key, 'ES256', headers)
+      end
+
+      def generateDPoP(url, ath, method, session_ephemeral_key_pair)
+        raise NotImplementedError
+      end
     end
+  end
 end

--- a/lib/myinfo/v4/security.rb
+++ b/lib/myinfo/v4/security.rb
@@ -4,22 +4,40 @@ require 'securerandom'
 require 'base64'
 require 'digest'
 require 'openssl'
+require 'jwe'
 require 'jwt'
+require 'json/jwt'
+require 'pry'
+require 'jose'
+require 'jose/jwe'
 
 module MyInfo
     module V4
         class Security
+            def config
+                MyInfo.configuration
+            end
+
+            def get_private_key
+                raise MissingConfigurationError, :private_key if config.private_key.blank?
+        
+                OpenSSL::PKey::RSA.new(config.private_key)
+            end
+
+            # done & tested
             def self.create_code_verifier 
                 code = SecureRandom.bytes(32)
                 Base64.urlsafe_encode64(code, padding: false)
             end
 
+            # done & tested
             def self.create_code_challenge(verifier)
                 bytes = verifier.encode('US-ASCII')
                 digest = Digest::SHA256.digest(bytes)
                 Base64.urlsafe_encode64(digest, padding: false)
             end
 
+            # not yet tested
             def self.generate_ephemeral_keys
                 key_pair = OpenSSL::PKey::EC.new("prime256v1")
                 key_pair.generate_key
@@ -32,27 +50,67 @@ module MyInfo
                 { private_key: private_key, public_key: public_key }
             end
 
+            def self.generate_ephemeral_keys_jose
+                private_key = JOSE::JWK.generate_key([:ec, "prime256v1"])
+                public_key = JOSE::JWK.to_public(private_key)
+                
+                { private_key: private_key.to_pem, public_key: public_key.to_pem }
+            end
+
+            # not yet tested
             def get_jwks(jwks_url)
-                raise NotImplementedError
+                uri = URI(jwks_url)
+                response = Net::HTTP.get_response(uri)
+
+                if response.is_a?(Net::HTTPSuccess)
+                    response_body = response.body
+                    response_data = JSON.parse(response_body)
+
+                    response_data['keys']
+                else 
+                    # Todo: Handle Error
+                end
             end
 
-            def verify_jws(compact_jws, jwks_url)
-                raise NotImplementedError
+            def self.decode_jws(compact_jws, public_key)
+                JWT.decode(jws, public_key, true, algorithm: 'ES256').first
             end
-
-            def decrypt_jwe(compact_jwe, decryption_private_key)
-                raise NotImplementedError
+            
+            def decrypt_jwe_with_key(compact_jwe, decryption_private_key)
+                jwe_parts = compact_jwe.split('.') # header.encryptedKey.iv.ciphertext.tag
+                raise 'Invalid data or signature' if jwe_parts.length != 5
+                
+                # Session encryption private key should correspond to the session encryption public key passed in to client assertion
+                key = JOSE::JWK.from_pem(decryption_private_key)
+                
+                data = {
+                    'type' => 'compact',
+                    'protected' => jwe_parts[0],
+                    'encrypted_key' => jwe_parts[1],
+                    'iv' => jwe_parts[2],
+                    'ciphertext' => jwe_parts[3],
+                    'tag' => jwe_parts[4],
+                    'header' => JSON.parse(JOSE::Util.base64url_decode(jwe_parts[0]).to_s)
+                }
+                
+                jwe = JOSE::JWE.from_serialized_compact(data.to_json)
+                result = jwe.decrypt(key)
+                
+                result.payload.to_s
+            rescue => error
+            'Error decrypting JWE'
             end
+            
 
+            # done & tested
             def self.generate_jwk_thumbprint(jwk)
-                jwk_key = OpenSSL::PKey::RSA.new(jwk)
-                jwk_thumbprint = Digest::SHA256.digest(jwk_key.public_key.to_der)
-                jwk_thumbprint_encoded = Base64.urlsafe_encode64(jk_thumbprint)
-
-                jwk_thumbprint_encoded
+                jwk_key = OpenSSL::PKey.read(jwk) # convert pem to OpenSSL::PKey::PKey object
+                jwk = JSON::JWK.new(jwk_key)
+                jwk.thumbprint('sha256')
             end
 
-            def self.generate_client_assertion(url, client_id, private_signing_key, jkt_thumbprint, kid)
+            # done & tested
+            def self.generate_client_assertion(url, client_id, private_signing_key, jwk_thumbprint, kid)
                 now = Time.now.to_i
                 payload = {
                     sub: client_id,
@@ -62,7 +120,7 @@ module MyInfo
                     iat: now,
                     exp: now + 300,
                     cnf: {
-                        jkt: jkt_thumbprint
+                        jkt: jwk_thumbprint
                     }
                 }
 
@@ -72,7 +130,7 @@ module MyInfo
                     'kid' => kid
                 }
 
-                jwt_token = JWT.encode(payload, private_key, 'RS256', headers)
+                jwt_token = JWT.encode(payload, private_key, 'ES256', headers)
 
                 jwt_token
             end

--- a/myinfo.gemspec
+++ b/myinfo.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jwe', '~> 0.4'
   s.add_dependency 'jwt', '~> 2.2'
+  s.add_dependency 'jose', '~> 0.1.0'
   s.add_development_dependency 'rails', '~> 6'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.10'

--- a/myinfo.gemspec
+++ b/myinfo.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jwe', '~> 0.4'
   s.add_dependency 'jwt', '~> 2.2'
-  s.add_dependency 'jose', '~> 0.1.0'
+  s.add_dependency 'jose', '~> 1.1.3'
+  s.add_dependency 'pry-rails'
+  s.add_dependency 'json-jwt'
   s.add_development_dependency 'rails', '~> 6'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.10'

--- a/spec/lib/myinfo/v4/security_spec.rb
+++ b/spec/lib/myinfo/v4/security_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe MyInfo::V4::Security do
+
+    describe '#create_code_verifier' do
+        it 'creates a code verifier of the correct length' do
+            code_verifier = described_class.create_code_verifier
+            expect(code_verifier).not_to be_empty
+        end
+    end
+
+    describe '#create_code_challenge' do 
+        let(:code_verifier) { 'U2ptdDRDMkNhYmF6MVlESTZuWXZ2dkVyMXhiVDNhZko' }
+
+        it 'returns the correct code_challenge' do
+            expect(described_class.create_code_challenge(code_verifier)).to eql('FkMwoc-HA4015MuSfEjjjPvxF0e82VxGHYP4Q8-12b4')
+        end
+    end
+
+    describe '#generate_client_assertion' do 
+        let(:url) { 'https://test.api.myinfo.gov.sg/com/v4/token' }
+        let(:client_id) { 'STG2-MYINFO-SELF-TEST' }
+        let(:private_signing_key) { "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIGcOBk0/8HtXAR8XkSinGpVE4GTmbPQnjkhGO+A+QrPaoAoGCCqGSM49AwEHoUQDQgAEBXUWq0Z2RRFqrlWbW2muIybNnj/YBxflNQTEOg+QmCS9c7gbjIOjSI5UkDOYRbIhnBfCdKcbE8itl7tJfQ8q7g==\n-----END EC PRIVATE KEY-----\n" }
+        let(:jkt_thumbprint) { 'G_q8Qv9-xv_9xJo-esolTnvxVSobMER7O0LKGPBlTqY' }
+        let(:kid) { 'aQPyZ72NM043E4KEioaHWzixt0owV99gC9kRK388WoQ' }
+
+        it 'successfully creates client_assertion' do 
+            client_assertion = described_class.generate_client_assertion(url, client_id, private_signing_key, jkt_thumbprint, kid)
+            expect(client_assertion).to_not be_empty
+        end
+    end
+end

--- a/spec/lib/myinfo/v4/security_spec.rb
+++ b/spec/lib/myinfo/v4/security_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'jwe'
+
 describe MyInfo::V4::Security do
 
     describe '#create_code_verifier' do
@@ -10,11 +12,33 @@ describe MyInfo::V4::Security do
     end
 
     describe '#create_code_challenge' do 
+        # code_verifier test case values taken from MyInfo's code challenge generator
         let(:code_verifier) { 'U2ptdDRDMkNhYmF6MVlESTZuWXZ2dkVyMXhiVDNhZko' }
-
+        let(:expected_code_challenge) { 'FkMwoc-HA4015MuSfEjjjPvxF0e82VxGHYP4Q8-12b4' }
         it 'returns the correct code_challenge' do
-            expect(described_class.create_code_challenge(code_verifier)).to eql('FkMwoc-HA4015MuSfEjjjPvxF0e82VxGHYP4Q8-12b4')
+            expect(described_class.create_code_challenge(code_verifier)).to eql(expected_code_challenge)
         end
+    end
+
+    describe '#generate_jwk_thumbprint' do 
+        # jwk and expected_jwk_thumbprint referenced from 'https://datatracker.ietf.org/doc/html/rfc7638' (ietf's jwk is converted to pem format here)
+        let(:jwk) { "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0vx7agoebGcQSuuPiLJX\nZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tS\noc/BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ/2W+5JsGY4Hc5n9yBXArwl93lqt\n7/RN5w6Cf0h4QyQ5v+65YGjQR0/FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0\nzgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt+bFTWhAI4vMQFh6WeZu0f\nM4lFd2NcRwr3XPksINHaQ+G/xBniIqbw0Ls1jF44+csFCur+kEgU8awapJzKnqDK\ngwIDAQAB\n-----END PUBLIC KEY-----"}
+        let(:expected_jwk_thumbprint) { 'NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs' }
+        it 'generates the correct jwk thumbprint' do 
+            expect(described_class.generate_jwk_thumbprint(jwk)).to eql(expected_jwk_thumbprint)
+        end
+    end
+
+    describe '#decrypt_jwe' do
+        let(:decrypted_text) { 'decrypted' }
+        let!(:key) { MyInfo::V4::Security.generate_ephemeral_keys }
+        let(:public_key) { OpenSSL::PKey::EC.new(key[:public_key])}
+        let(:encrypted_text) { JWE.encrypt(decrypted_text, ) }
+
+        before do 
+
+        end
+        
     end
 
     describe '#generate_client_assertion' do 

--- a/spec/lib/myinfo/v4/security_spec.rb
+++ b/spec/lib/myinfo/v4/security_spec.rb
@@ -3,54 +3,53 @@
 require 'jwe'
 
 describe MyInfo::V4::Security do
-
-    describe '#create_code_verifier' do
-        it 'creates a code verifier of the correct length' do
-            code_verifier = described_class.create_code_verifier
-            expect(code_verifier).not_to be_empty
-        end
+  describe '#create_code_verifier' do
+    it 'creates a code verifier of the correct length' do
+      code_verifier = described_class.create_code_verifier
+      expect(code_verifier).not_to be_empty
     end
+  end
 
-    describe '#create_code_challenge' do 
-        # code_verifier test case values taken from MyInfo's code challenge generator
-        let(:code_verifier) { 'U2ptdDRDMkNhYmF6MVlESTZuWXZ2dkVyMXhiVDNhZko' }
-        let(:expected_code_challenge) { 'FkMwoc-HA4015MuSfEjjjPvxF0e82VxGHYP4Q8-12b4' }
-        it 'returns the correct code_challenge' do
-            expect(described_class.create_code_challenge(code_verifier)).to eql(expected_code_challenge)
-        end
+  describe '#create_code_challenge' do
+    # code_verifier test case values taken from MyInfo's code challenge generator
+    let(:code_verifier) { 'U2ptdDRDMkNhYmF6MVlESTZuWXZ2dkVyMXhiVDNhZko' }
+    let(:expected_code_challenge) { 'FkMwoc-HA4015MuSfEjjjPvxF0e82VxGHYP4Q8-12b4' }
+    it 'returns the correct code_challenge' do
+      expect(described_class.create_code_challenge(code_verifier)).to eql(expected_code_challenge)
     end
+  end
 
-    describe '#generate_jwk_thumbprint' do 
-        # jwk and expected_jwk_thumbprint referenced from 'https://datatracker.ietf.org/doc/html/rfc7638' (ietf's jwk is converted to pem format here)
-        let(:jwk) { "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0vx7agoebGcQSuuPiLJX\nZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tS\noc/BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ/2W+5JsGY4Hc5n9yBXArwl93lqt\n7/RN5w6Cf0h4QyQ5v+65YGjQR0/FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0\nzgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt+bFTWhAI4vMQFh6WeZu0f\nM4lFd2NcRwr3XPksINHaQ+G/xBniIqbw0Ls1jF44+csFCur+kEgU8awapJzKnqDK\ngwIDAQAB\n-----END PUBLIC KEY-----"}
-        let(:expected_jwk_thumbprint) { 'NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs' }
-        it 'generates the correct jwk thumbprint' do 
-            expect(described_class.generate_jwk_thumbprint(jwk)).to eql(expected_jwk_thumbprint)
-        end
+  describe '#generate_jwk_thumbprint' do
+    # jwk and expected_jwk_thumbprint referenced from 'https://datatracker.ietf.org/doc/html/rfc7638' (ietf's jwk is converted to pem format here)
+    let(:jwk) { "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0vx7agoebGcQSuuPiLJX\nZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tS\noc/BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ/2W+5JsGY4Hc5n9yBXArwl93lqt\n7/RN5w6Cf0h4QyQ5v+65YGjQR0/FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0\nzgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt+bFTWhAI4vMQFh6WeZu0f\nM4lFd2NcRwr3XPksINHaQ+G/xBniIqbw0Ls1jF44+csFCur+kEgU8awapJzKnqDK\ngwIDAQAB\n-----END PUBLIC KEY-----"}
+    let(:expected_jwk_thumbprint) { 'NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs' }
+    it 'generates the correct jwk thumbprint' do
+      expect(described_class.generate_jwk_thumbprint(jwk)).to eql(expected_jwk_thumbprint)
     end
+  end
 
-    describe '#decrypt_jwe' do
-        let(:decrypted_text) { 'decrypted' }
-        let!(:key) { MyInfo::V4::Security.generate_ephemeral_keys }
-        let(:public_key) { OpenSSL::PKey::EC.new(key[:public_key])}
-        let(:encrypted_text) { JWE.encrypt(decrypted_text, ) }
+  describe '#decrypt_jwe' do
+    let(:decrypted_text) { 'decrypted' }
+    let(:private_key) { JOSE::JWK.generate_key([:ec, 'P-256']) }
+    let(:private_key_pem) { JOSE::JWK.to_pem(private_key) }
+    let(:public_key) { JOSE::JWK.to_public(private_key) }
+    let(:encrypted_jwe) { JOSE::JWE.block_encrypt([public_key, private_key], decrypted_text, { 'alg' => 'ECDH-ES', 'enc' => 'A128GCM'}).compact }
 
-        before do 
-
-        end
-        
+    it 'correctly decrypts the encrypted text' do
+      expect(described_class.decrypt_jwe(encrypted_jwe, private_key_pem)).to eq('decrypted')
     end
+  end
 
-    describe '#generate_client_assertion' do 
-        let(:url) { 'https://test.api.myinfo.gov.sg/com/v4/token' }
-        let(:client_id) { 'STG2-MYINFO-SELF-TEST' }
-        let(:private_signing_key) { "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIGcOBk0/8HtXAR8XkSinGpVE4GTmbPQnjkhGO+A+QrPaoAoGCCqGSM49AwEHoUQDQgAEBXUWq0Z2RRFqrlWbW2muIybNnj/YBxflNQTEOg+QmCS9c7gbjIOjSI5UkDOYRbIhnBfCdKcbE8itl7tJfQ8q7g==\n-----END EC PRIVATE KEY-----\n" }
-        let(:jkt_thumbprint) { 'G_q8Qv9-xv_9xJo-esolTnvxVSobMER7O0LKGPBlTqY' }
-        let(:kid) { 'aQPyZ72NM043E4KEioaHWzixt0owV99gC9kRK388WoQ' }
+  describe '#generate_client_assertion' do
+    let(:url) { 'https://test.api.myinfo.gov.sg/com/v4/token' }
+    let(:client_id) { 'STG2-MYINFO-SELF-TEST' }
+    let(:private_signing_key) { "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIGcOBk0/8HtXAR8XkSinGpVE4GTmbPQnjkhGO+A+QrPaoAoGCCqGSM49AwEHoUQDQgAEBXUWq0Z2RRFqrlWbW2muIybNnj/YBxflNQTEOg+QmCS9c7gbjIOjSI5UkDOYRbIhnBfCdKcbE8itl7tJfQ8q7g==\n-----END EC PRIVATE KEY-----\n" }
+    let(:jkt_thumbprint) { 'G_q8Qv9-xv_9xJo-esolTnvxVSobMER7O0LKGPBlTqY' }
+    let(:kid) { 'aQPyZ72NM043E4KEioaHWzixt0owV99gC9kRK388WoQ' }
 
-        it 'successfully creates client_assertion' do 
-            client_assertion = described_class.generate_client_assertion(url, client_id, private_signing_key, jkt_thumbprint, kid)
-            expect(client_assertion).to_not be_empty
-        end
+    it 'successfully creates client_assertion' do
+      client_assertion = described_class.generate_client_assertion(url, client_id, private_signing_key, jkt_thumbprint, kid)
+      expect(client_assertion).to_not be_empty
     end
+  end
 end


### PR DESCRIPTION
This PR serves to set up the security helpers required in V4 (Currently work in progress), namely we should be able to:

1. generate ephemeral keys
2. generate client assertions
3. generate DPoPs
4. generate PKCE code challenges
5. retrieve jwks from jwks url
6. decrypt jwe
7. decode jws
8. generate jwk thumbprints

Feel free to let me know on any improvements on the code!